### PR TITLE
Update README.md because the link was dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keebacy
 
-[Link to website](https://madnight.github.io/keybacy/)
+[Link to website](https://madnight.github.io/keebacy/)
 
 A minimalist typing program inspired by [wpm](https://github.com/cjbassi/wpm-spa) and built for the browser using React and Redux.
 It includes different typing modes such as 'words', 'quote', 'wiki', and 'custom', and gives you typing stats based on the current text being typed.


### PR DESCRIPTION
Apparently the tool has been renamed from keybacy, because the link had to renamed to work. :)